### PR TITLE
set max gas to double of the charged gas for the 'intrinsic' smart co…

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -211,7 +211,9 @@ func (st *StateTransition) canBuyGas(accountOwner common.Address, gasNeeded *big
 	if gasCurrency == nil {
 		return st.state.GetBalance(accountOwner).Cmp(gasNeeded) > 0
 	}
-	balanceOf, _, err := currency.GetBalanceOf(accountOwner, *gasCurrency, params.MaxGasToReadErc20Balance, st.evm.GetHeader(), st.evm.GetStateDB())
+	balanceOf, gasUsed, err := currency.GetBalanceOf(accountOwner, *gasCurrency, params.MaxGasToReadErc20Balance, st.evm.GetHeader(), st.evm.GetStateDB())
+	log.Debug("balanceOf called", "gasCurrency", *gasCurrency, "gasUsed", gasUsed)
+
 	if err != nil {
 		return false
 	}
@@ -233,7 +235,9 @@ func (st *StateTransition) debitFrom(address common.Address, amount *big.Int, ga
 
 	rootCaller := vm.AccountRef(common.HexToAddress("0x0"))
 	// The caller was already charged for the cost of this operation via IntrinsicGas.
-	_, _, err := evm.Call(rootCaller, *gasCurrency, transactionData, params.MaxGasForDebitFromTransactions, big.NewInt(0))
+	_, leftoverGas, err := evm.Call(rootCaller, *gasCurrency, transactionData, params.MaxGasForDebitFromTransactions, big.NewInt(0))
+	gasUsed := params.MaxGasForDebitFromTransactions - leftoverGas
+	log.Debug("debitFrom called", "gasCurrency", *gasCurrency, "gasUsed", gasUsed)
 	return err
 }
 
@@ -251,7 +255,9 @@ func (st *StateTransition) creditTo(address common.Address, amount *big.Int, gas
 	transactionData := common.GetEncodedAbi(functionSelector, [][]byte{common.AddressToAbi(address), common.AmountToAbi(amount)})
 	rootCaller := vm.AccountRef(common.HexToAddress("0x0"))
 	// The caller was already charged for the cost of this operation via IntrinsicGas.
-	_, _, err := evm.Call(rootCaller, *gasCurrency, transactionData, params.MaxGasForCreditToTransactions, big.NewInt(0))
+	_, leftoverGas, err := evm.Call(rootCaller, *gasCurrency, transactionData, params.MaxGasForCreditToTransactions, big.NewInt(0))
+	gasUsed := params.MaxGasForCreditToTransactions - leftoverGas
+	log.Debug("creditTo called", "gasCurrency", *gasCurrency, "gasUsed", gasUsed)
 	return err
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -139,11 +139,20 @@ const (
 	// TODO(asa): Make these operations less expensive by charging only what is used.
 	// The problem is we don't know how much to refund until the refund is complete.
 	// If these values are changed, "setDefaults" will need updating.
-	MaxGasForDebitFromTransactions      uint64 = 38 * 1000
+
+	// The plan is to have these values set within a system smart contract,
+	// and that they are read during runtime.  They could then be changed via
+	// governance.
 	ExpectedGasForDebitFromTransactions uint64 = 23 * 1000
-	MaxGasForCreditToTransactions       uint64 = 32 * 1000
-	MaxGasToReadErc20Balance            uint64 = 15 * 1000
-	MaxGasToReadTobinTax                uint64 = 50 * 1000
+	MaxGasForDebitFromTransactions      uint64 = 46 * 1000
+
+	ExpectedGasForCreditToTransactions uint64 = 32 * 1000
+	MaxGasForCreditToTransactions      uint64 = 64 * 1000
+
+	ExpectedGasToReadErc20Balance uint64 = 15 * 1000
+	MaxGasToReadErc20Balance      uint64 = 30 * 1000
+
+	MaxGasToReadTobinTax uint64 = 50 * 1000
 	// We charge for reading the balance, 1 debit, and 3 credits (refunding gas, paying the gas fee recipient, sending to the infrastructure fund)
-	AdditionalGasForNonGoldCurrencies uint64 = 3*MaxGasForCreditToTransactions + ExpectedGasForDebitFromTransactions + MaxGasToReadErc20Balance
+	AdditionalGasForNonGoldCurrencies uint64 = 3*ExpectedGasForCreditToTransactions + ExpectedGasForDebitFromTransactions + ExpectedGasToReadErc20Balance
 )


### PR DESCRIPTION
…ntract calls (#472)

* set max gas to double of the charged gas for the 'intrinsic' evm operations

* addressed PR comments

* addressed pr comment

### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Other changes

_Describe any minor or "drive-by" changes here._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible. Feel free to remove for trivial, backwards compatible changes._
